### PR TITLE
ETEP-87 deploy in outra

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ The Tableau Server cluster (multi-node) deployment installs Tableau Server on th
 
 
 Deployment Guide: https://s3.amazonaws.com/quickstart-reference/tableau/server/latest/doc/tableau-server-on-the-aws-cloud.pdf
+
+
+# Template Information
+
+To pull an existing stack's parameters (make sure to edit password fields):
+
+```bash
+$ aws cloudformation describe-stacks --stack-name "Tableau-Server-Dev-Cf-7" --profile outra-dev | jq '.Stacks[0].Parameters' > templates/some-emv.json
+```
+
+To validate a template:
+
+```bash
+$ aws cloudformation validate-template --template-body file://templates/tableau-single-server.template
+```

--- a/templates/outra-data.json
+++ b/templates/outra-data.json
@@ -1,0 +1,114 @@
+[
+  {
+    "ParameterKey": "RegIndustry",
+    "ParameterValue": "Big Data"
+  },
+  {
+    "ParameterKey": "VPCID",
+    "ParameterValue": "vpc-ad3d11c9"
+  },
+  {
+    "ParameterKey": "RegLastName",
+    "ParameterValue": "Law"
+  },
+  {
+    "ParameterKey": "RegPhone",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "RegFirstName",
+    "ParameterValue": "Cyril"
+  },
+  {
+    "ParameterKey": "RegTitle",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "RegDepartment",
+    "ParameterValue": "Technology"
+  },
+  {
+    "ParameterKey": "SmtpFromAddress",
+    "ParameterValue": "tableau@outra.co.uk"
+  },
+  {
+    "ParameterKey": "RegCompany",
+    "ParameterValue": "Outra Ltd"
+  },
+  {
+    "ParameterKey": "PublicPortalUrl",
+    "ParameterValue": "http://tableau.int.outra.co.uk"
+  },
+  {
+    "ParameterKey": "DataVolumeSize",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "ContentAdminPassword",
+    "ParameterValue": "****"
+  },
+  {
+    "ParameterKey": "RegCity",
+    "ParameterValue": "London"
+  },
+  {
+    "ParameterKey": "TableauServerLicenseKey",
+    "ParameterValue": "****"
+  },
+  {
+    "ParameterKey": "ResourceAvailabilityZone",
+    "ParameterValue": "eu-west-1a"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "KeyPairLinux1_AWS_A"
+  },
+  {
+    "ParameterKey": "RegZip",
+    "ParameterValue": "SW1 00XF"
+  },
+  {
+    "ParameterKey": "SmtpUrl",
+    "ParameterValue": "outra-co-uk.mail.protection.outlook.com"
+  },
+  {
+    "ParameterKey": "SmtpPassword",
+    "ParameterValue": "****"
+  },
+  {
+    "ParameterKey": "PrimarySubnetID",
+    "ParameterValue": "subnet-526b120a"
+  },
+  {
+    "ParameterKey": "SmtpUserName",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "RegCountry",
+    "ParameterValue": "UK"
+  },
+  {
+    "ParameterKey": "InstanceSecurityGroup",
+    "ParameterValue": "sg-6bfa3512"
+  },
+  {
+    "ParameterKey": "RegEmail",
+    "ParameterValue": "it@outra.co.uk"
+  },
+  {
+    "ParameterKey": "ServerName",
+    "ParameterValue": "ire-tableau-01-a"
+  },
+  {
+    "ParameterKey": "SmtpAlertToAddress",
+    "ParameterValue": "awsaccount-dev@outra.co.uk"
+  },
+  {
+    "ParameterKey": "RegState",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "ContentAdminUser",
+    "ParameterValue": "admin"
+  }
+]

--- a/templates/outra-dev.json
+++ b/templates/outra-dev.json
@@ -1,106 +1,114 @@
 [
-    {
-        "ParameterKey": "RegIndustry",
-        "ParameterValue": "Big Data"
-    },
-    {
-        "ParameterKey": "VPCID",
-        "ParameterValue": "vpc-2a23fa4c"
-    },
-    {
-        "ParameterKey": "RegLastName",
-        "ParameterValue": "Law"
-    },
-    {
-        "ParameterKey": "RegPhone",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "RegFirstName",
-        "ParameterValue": "Cyril"
-    },
-    {
-        "ParameterKey": "RegTitle",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "RegDepartment",
-        "ParameterValue": "Technology"
-    },
-    {
-        "ParameterKey": "SmtpFromAddress",
-        "ParameterValue": "tableau@outra.co.uk"
-    },
-    {
-        "ParameterKey": "RegCompany",
-        "ParameterValue": "Outra Ltd"
-    },
-    {
-        "ParameterKey": "RegCity",
-        "ParameterValue": "London"
-    },
-    {
-        "ParameterKey": "ResourceAvailabilityZone",
-        "ParameterValue": "eu-west-1a"
-    },
-    {
-        "ParameterKey": "TableauServerLicenseKey",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "OutraCloudFormationDev"
-    },
-    {
-        "ParameterKey": "RegZip",
-        "ParameterValue": "SW1 00XF"
-    },
-    {
-        "ParameterKey": "AWSPublicFQDN",
-        "ParameterValue": "ire-tableau-a-7.int.outra.co."
-    },
-    {
-        "ParameterKey": "SmtpUrl",
-        "ParameterValue": "outra-co-uk.mail.protection.outlook.com"
-    },
-    {
-        "ParameterKey": "SmtpPassword",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "PrimarySubnetID",
-        "ParameterValue": "subnet-0a724d51"
-    },
-    {
-        "ParameterKey": "SmtpUserName",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "RegCountry",
-        "ParameterValue": "UK"
-    },
-    {
-        "ParameterKey": "InstanceSecurityGroup",
-        "ParameterValue": "sg-62d56218"
-    },
-    {
-        "ParameterKey": "RegEmail",
-        "ParameterValue": "it@outra.co.uk"
-    },
-    {
-        "ParameterKey": "ServerName",
-        "ParameterValue": "ire-tableau-a-dev-7"
-    },
-    {
-        "ParameterKey": "SmtpAlertToAddress",
-        "ParameterValue": "awsaccount-dev@outra.co.uk"
-    },
-    {
-        "ParameterKey": "RegState",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "ContentAdminUser",
-        "ParameterValue": "admin"
-    }
+  {
+    "ParameterKey": "RegIndustry",
+    "ParameterValue": "Big Data"
+  },
+  {
+    "ParameterKey": "VPCID",
+    "ParameterValue": "vpc-2a23fa4c"
+  },
+  {
+    "ParameterKey": "RegLastName",
+    "ParameterValue": "Law"
+  },
+  {
+    "ParameterKey": "RegPhone",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "RegFirstName",
+    "ParameterValue": "Cyril"
+  },
+  {
+    "ParameterKey": "RegTitle",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "RegDepartment",
+    "ParameterValue": "Technology"
+  },
+  {
+    "ParameterKey": "SmtpFromAddress",
+    "ParameterValue": "tableau@outra.co.uk"
+  },
+  {
+    "ParameterKey": "RegCompany",
+    "ParameterValue": "Outra Ltd"
+  },
+  {
+    "ParameterKey": "PublicPortalUrl",
+    "ParameterValue": "http://tableau.int.outra.co.uk"
+  },
+  {
+    "ParameterKey": "DataVolumeSize",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "ContentAdminPassword",
+    "ParameterValue": "****"
+  },
+  {
+    "ParameterKey": "RegCity",
+    "ParameterValue": "London"
+  },
+  {
+    "ParameterKey": "TableauServerLicenseKey",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "ResourceAvailabilityZone",
+    "ParameterValue": "eu-west-1a"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "OutraCloudFormationDev"
+  },
+  {
+    "ParameterKey": "RegZip",
+    "ParameterValue": "SW1 00XF"
+  },
+  {
+    "ParameterKey": "SmtpUrl",
+    "ParameterValue": "outra-co-uk.mail.protection.outlook.com"
+  },
+  {
+    "ParameterKey": "SmtpPassword",
+    "ParameterValue": "****"
+  },
+  {
+    "ParameterKey": "PrimarySubnetID",
+    "ParameterValue": "subnet-0a724d51"
+  },
+  {
+    "ParameterKey": "SmtpUserName",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "RegCountry",
+    "ParameterValue": "UK"
+  },
+  {
+    "ParameterKey": "InstanceSecurityGroup",
+    "ParameterValue": "sg-62d56218"
+  },
+  {
+    "ParameterKey": "RegEmail",
+    "ParameterValue": "it@outra.co.uk"
+  },
+  {
+    "ParameterKey": "ServerName",
+    "ParameterValue": "ire-tableau-a-dev-8"
+  },
+  {
+    "ParameterKey": "SmtpAlertToAddress",
+    "ParameterValue": "awsaccount-dev@outra.co.uk"
+  },
+  {
+    "ParameterKey": "RegState",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "ContentAdminUser",
+    "ParameterValue": "admin"
+  }
 ]

--- a/templates/outra-dev.json
+++ b/templates/outra-dev.json
@@ -1,0 +1,106 @@
+[
+    {
+        "ParameterKey": "RegIndustry",
+        "ParameterValue": "Big Data"
+    },
+    {
+        "ParameterKey": "VPCID",
+        "ParameterValue": "vpc-2a23fa4c"
+    },
+    {
+        "ParameterKey": "RegLastName",
+        "ParameterValue": "Law"
+    },
+    {
+        "ParameterKey": "RegPhone",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "RegFirstName",
+        "ParameterValue": "Cyril"
+    },
+    {
+        "ParameterKey": "RegTitle",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "RegDepartment",
+        "ParameterValue": "Technology"
+    },
+    {
+        "ParameterKey": "SmtpFromAddress",
+        "ParameterValue": "tableau@outra.co.uk"
+    },
+    {
+        "ParameterKey": "RegCompany",
+        "ParameterValue": "Outra Ltd"
+    },
+    {
+        "ParameterKey": "RegCity",
+        "ParameterValue": "London"
+    },
+    {
+        "ParameterKey": "ResourceAvailabilityZone",
+        "ParameterValue": "eu-west-1a"
+    },
+    {
+        "ParameterKey": "TableauServerLicenseKey",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "OutraCloudFormationDev"
+    },
+    {
+        "ParameterKey": "RegZip",
+        "ParameterValue": "SW1 00XF"
+    },
+    {
+        "ParameterKey": "AWSPublicFQDN",
+        "ParameterValue": "ire-tableau-a-7.int.outra.co."
+    },
+    {
+        "ParameterKey": "SmtpUrl",
+        "ParameterValue": "outra-co-uk.mail.protection.outlook.com"
+    },
+    {
+        "ParameterKey": "SmtpPassword",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "PrimarySubnetID",
+        "ParameterValue": "subnet-0a724d51"
+    },
+    {
+        "ParameterKey": "SmtpUserName",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "RegCountry",
+        "ParameterValue": "UK"
+    },
+    {
+        "ParameterKey": "InstanceSecurityGroup",
+        "ParameterValue": "sg-62d56218"
+    },
+    {
+        "ParameterKey": "RegEmail",
+        "ParameterValue": "it@outra.co.uk"
+    },
+    {
+        "ParameterKey": "ServerName",
+        "ParameterValue": "ire-tableau-a-dev-7"
+    },
+    {
+        "ParameterKey": "SmtpAlertToAddress",
+        "ParameterValue": "awsaccount-dev@outra.co.uk"
+    },
+    {
+        "ParameterKey": "RegState",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "ContentAdminUser",
+        "ParameterValue": "admin"
+    }
+]

--- a/templates/outra-dev.json
+++ b/templates/outra-dev.json
@@ -97,7 +97,7 @@
   },
   {
     "ParameterKey": "ServerName",
-    "ParameterValue": "ire-tableau-a-dev-8"
+    "ParameterValue": "ire-tableau-a-dev-9"
   },
   {
     "ParameterKey": "SmtpAlertToAddress",

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "AWS QuickStart Template for Tableau Server instance running on Windows QS(0040)",
+    "Description": "Outra Tableau Server deployment based on the AWS QuickStart Template for Tableau Server instance running on Windows QS(0040)",
     "Parameters": {
         "ContentAdminPassword": {
             "Description": "The password for the initial Admin user for Tableau server",
@@ -13,6 +13,32 @@
             "Description": "The name of the initial Admin user for Tableau server",
             "MinLength": "1",
             "Type": "String"
+        },
+        "ServerName": {
+            "Type": "String",
+            "MinLength": "1",
+            "Description": "Value of the Name tag"
+        },
+        "SmtpUrl": {
+            "Type": "String",
+            "Description": "SMTP server to use for notifications (port 25, no SSL)"
+        },
+        "SmtpFromAddress": {
+            "Type": "String",
+            "Description": "Address from which notifications come"
+        },
+        "SmtpAlertToAddress": {
+            "Type": "String",
+            "Description": "Address to which server alerts are sent"
+        },
+        "SmtpUserName": {
+            "Type": "String",
+            "Description": "Username used to connect to SMTP (optional)"
+        },
+        "SmtpPassword": {
+            "Type": "String",
+            "Description": "Password used to connect to SMTP (optional)",
+            "NoEcho": "true"
         },
         "KeyPairName": {
             "ConstraintDescription": "The name of an existing EC2 KeyPair.",
@@ -58,19 +84,34 @@
         "RegZip": {
             "Type": "String"
         },
+        "TableauServerLicenseKey": {
+            "Description": "License Key (leave blank for trial)",
+            "Type": "String"
+        },
         "ResourceAvailabilityZone": {
             "Description": "The availability zone in which our server and storage volume reside",
             "Type": "AWS::EC2::AvailabilityZone::Name"
         },
-        "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
-            "Description": "The CIDR address from which you will connect to the instance",
+        "InstanceSecurityGroup": {
+            "Description": "The security group to add to this instance. Should have RDP (Port 3389) and HTTP (Port 80) open.",
+            "Type": "AWS::EC2::SecurityGroup::Id"
+        },
+        "VPCID": {
+            "Description": "The ID of the VPC into which to deploy the instance",
+            "Type": "AWS::EC2::VPC::Id"
+        },
+        "PrimarySubnetID": {
+            "Description": "The ID of the subnet for the server",
+            "Type": "AWS::EC2::Subnet::Id"
+        },
+        "PublicPortalUrl": {
+            "Description": "Tableau Server portal will be reachable at this address",
             "Type": "String"
         },
-        "TableauServerLicenseKey": {
-            "Description": "License Key (leave blank for trial)",
-            "Type": "String"
+        "DataVolumeSize": {
+            "Description": "The size of this server's Data volume in GB",
+            "Type": "Number",
+            "Default": "100"
         }
     },
     "Metadata": {
@@ -83,7 +124,12 @@
                     "Parameters": [
                         "KeyPairName",
                         "ResourceAvailabilityZone",
-                        "SourceCIDR"
+                        "InstanceSecurityGroup",
+                        "ServerName",
+                        "VPCID",
+                        "PrimarySubnetID",
+                        "PublicPortalUrl",
+                        "DataVolumeSize"
                     ]
                 },
                 {
@@ -114,11 +160,26 @@
                         "RegZip",
                         "RegCountry"
                     ]
+                },
+                {
+                    "Label": {
+                        "default": "SMTP"
+                    },
+                    "Parameters": [
+                        "SmtpUrl",
+                        "SmtpUserName",
+                        "SmtpPassword",
+                        "SmtpFromAddress",
+                        "SmtpAlertToAddress"
+                    ]
                 }
             ],
             "ParameterLabels": {
                 "KeyPairName": {
                     "default": "Key Pair Name"
+                },
+                "ServerName": {
+                    "default": "The name of this EC2 instance"
                 },
                 "ResourceAvailabilityZone": {
                     "default": "Target Availability Zone"
@@ -170,6 +231,36 @@
                 },
                 "RegCountry": {
                     "default": "Country"
+                },
+                "InstanceSecurityGroup": {
+                    "default": "Existing destination Security Group"
+                },
+                "PublicPortalUrl": {
+                    "default": "Full DNS Name for Cluster"
+                },
+                "PrimarySubnetID": {
+                    "default": "Primary Server Subnet ID"
+                },
+                "VPCID": {
+                    "default": "VPC ID"
+                },
+                "SmtpUrl": {
+                    "default": "SMTP server"
+                },
+                "SmtpUserName": {
+                    "default": "Username"
+                },
+                "SmtpPassword": {
+                    "default": "Password"
+                },
+                "SmtpFromAddress": {
+                    "default": "From Address"
+                },
+                "SmtpAlertToAddress": {
+                    "default": "To Address"
+                },
+                "DataVolumeSize": {
+                    "default": "Size in GB"
                 }
             }
         }
@@ -230,7 +321,6 @@
             "MachineConfiguration": {
                 "InstanceType": "m4.4xlarge",
                 "SystemVolumeSize": 50,
-                "DataVolumeSize": 100,
                 "WindowsVersion": "WS2012R2"
             }
         }
@@ -246,39 +336,42 @@
         }
     },
     "Resources": {
-        "InstanceSecurityGroup": {
-            "Type": "AWS::EC2::SecurityGroup",
-            "Properties": {
-                "GroupDescription": "Enable RDP",
-                "SecurityGroupIngress": [
-                    {
-                        "IpProtocol": "tcp",
-                        "FromPort": "3389",
-                        "ToPort": "3389",
-                        "CidrIp": {
-                            "Ref": "SourceCIDR"
-                        }
-                    },
-                    {
-                        "IpProtocol": "tcp",
-                        "FromPort": "80",
-                        "ToPort": "80",
-                        "CidrIp": {
-                            "Ref": "SourceCIDR"
-                        }
-                    }
-                ]
-            }
-        },
         "TableauWindowsServer": {
             "Type": "AWS::EC2::Instance",
-            "DependsOn": [
-                "InstanceSecurityGroup"
-            ],
             "Metadata": {
                 "AWS::CloudFormation::Init": {
                     "config": {
+                        "packages": {
+                            "msi": {
+                                "python": "https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi"
+                            }
+                        },
                         "files": {
+                            "c:\\tabsetup\\json2yml.py": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "\n",
+                                        [
+                                            "import sys",
+                                            "import yaml",
+                                            "import json",
+                                            "config_data = json.load(sys.stdin)",
+                                            "for k,v in config_data.items():",
+                                            "    if v.startswith('INTEGER:'):",
+                                            "        newvalue = v[len('INTEGER:'):]",
+                                            "        config_data[k] = int(newvalue)",
+                                            "    elif v.startswith('FLOAT:'):",
+                                            "        newvalue = v[len('FLOAT:'):]",
+                                            "        config_data[k] = float(newvalue)",
+                                            "    elif v.startswith('BOOLEAN:'):",
+                                            "        newvalue = v[len('BOOLEAN:'):]",
+                                            "        config_data[k] = json.loads(newvalue.lower())",
+                                            "yaml.safe_dump(config_data, sys.stdout, default_flow_style=False)",
+                                            ""
+                                        ]
+                                    ]
+                                }
+                            },
                             "c:\\tabsetup\\secrets.json": {
                                 "content": {
                                     "content_admin_user": {
@@ -337,6 +430,34 @@
                                     }
                                 }
                             },
+                            "c:\\tabsetup\\config.json": {
+                                "content": {
+                                    "config.version": "INTEGER:17",
+                                    "install.component.samples": "BOOLEAN:true",
+                                    "wgserver.authenticate": "local",
+                                    "storage.monitoring.email_enabled": "BOOLEAN:true",
+                                    "storage.monitoring.email_interval_min": "INTEGER:300",
+                                    "svcmonitor.notification.smtp.canonical_url": {
+                                        "Ref": "PublicPortalUrl"
+                                    },
+                                    "svcmonitor.notification.smtp.enabled": "BOOLEAN:true",
+                                    "svcmonitor.notification.smtp.from_address": {
+                                        "Ref": "SmtpFromAddress"
+                                    },
+                                    "svcmonitor.notification.smtp.send_account": {
+                                        "Ref": "SmtpUserName"
+                                    },
+                                    "svcmonitor.notification.smtp.password": {
+                                        "Ref": "SmtpPassword"
+                                    },
+                                    "svcmonitor.notification.smtp.server": {
+                                        "Ref": "SmtpUrl"
+                                    },
+                                    "svcmonitor.notification.smtp.target_addresses": {
+                                        "Ref": "SmtpAlertToAddress"
+                                    }
+                                }
+                            },
                             "c:\\tabsetup\\ScriptedInstaller.py": {
                                 "source": {
                                     "Fn::Join": [
@@ -354,9 +475,6 @@
                                         ]
                                     ]
                                 }
-                            },
-                            "c:\\tabsetup\\python-2.7.12.msi": {
-                                "source": "https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi"
                             },
                             "c:\\tabsetup\\tableau-server-installer.exe": {
                                 "source": {
@@ -385,14 +503,14 @@
                             }
                         },
                         "commands": {
-                            "1-install-python": {
-                                "command": "c:\\tabsetup\\python-2.7.12.msi /quiet /qn",
-                                "cwd": "c:\\tabsetup",
+                            "1-pip-install-yaml": {
+                                "command": "c:\\Python27\\Scripts\\pip.exe install pyyaml boto3",
+                                "cwd": "c:\\Python27\\Scripts",
                                 "waitAfterCompletion": "0"
                             },
-                            "2-pip-install-yaml": {
-                                "command": "c:\\Python27\\Scripts\\pip.exe install pyyaml",
-                                "cwd": "c:\\Python27\\Scripts",
+                            "2-convert-config": {
+                                "cwd": "c:\\tabsetup",
+                                "command": "type config.json | c:\\Python27\\python json2yml.py > config.yml",
                                 "waitAfterCompletion": "0"
                             },
                             "3-run-installer": {
@@ -409,6 +527,7 @@
                                             "--enablePublicFwRule",
                                             "--secretsFile c:\\tabsetup\\secrets.json",
                                             "--registrationFile c:\\tabsetup\\registration.json",
+                                            "--configFile c:\\tabsetup\\config.yml",
                                             "--installDir d:\\tableau",
                                             {
                                                 "Fn::If": [
@@ -479,11 +598,7 @@
                         "DeviceName": "xvdc",
                         "Ebs": {
                             "VolumeSize": {
-                                "Fn::FindInMap": [
-                                    "DefaultConfiguration",
-                                    "MachineConfiguration",
-                                    "DataVolumeSize"
-                                ]
+                                "Ref": "DataVolumeSize"
                             },
                             "VolumeType": "gp2"
                         }
@@ -496,6 +611,9 @@
                 ],
                 "KeyName": {
                     "Ref": "KeyPairName"
+                },
+                "SubnetId": {
+                    "Ref": "PrimarySubnetID"
                 },
                 "UserData": {
                     "Fn::Base64": {
@@ -527,7 +645,7 @@
                     {
                         "Key": "Name",
                         "Value": {
-                            "Fn::Sub": "${AWS::StackName}-cfn-tableau-server"
+                            "Ref": "ServerName"
                         }
                     }
                 ]
@@ -553,21 +671,21 @@
                 "Ref": "TableauWindowsServer"
             }
         },
-        "PublicIPAddress": {
-            "Description": "Public IP Address of instance running Tableau Server",
+        "PrivateIPAddress": {
+            "Description": "Private IP Address of instance running Tableau Server",
             "Value": {
                 "Fn::GetAtt": [
                     "TableauWindowsServer",
-                    "PublicIp"
+                    "PrivateIp"
                 ]
             }
         },
-        "PublicDNSName": {
-            "Description": "Public DNS name of instance running Tableau Server",
+        "PrivateDNSName": {
+            "Description": "Private DNS name of instance running Tableau Server",
             "Value": {
                 "Fn::GetAtt": [
                     "TableauWindowsServer",
-                    "PublicDnsName"
+                    "PrivateDnsName"
                 ]
             }
         }

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -619,7 +619,7 @@
                         }
                     }
                 ],
-                "SecurityGroups": [
+                "SecurityGroupIds": [
                     {
                         "Ref": "InstanceSecurityGroup"
                     }

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -101,7 +101,8 @@
         },
         "TableauServerLicenseKey": {
             "Description": "License Key (leave blank for trial)",
-            "Type": "String"
+            "Type": "String",
+            "NoEcho": "true"
         },
         "ResourceAvailabilityZone": {
             "Description": "The availability zone in which our server and storage volume reside",

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -21,15 +21,18 @@
         },
         "SmtpUrl": {
             "Type": "String",
-            "Description": "SMTP server to use for notifications (port 25, no SSL)"
+            "Description": "SMTP server to use for notifications (port 25, no SSL)",
+            "Default": "outra-co-uk.mail.protection.outlook.com"
         },
         "SmtpFromAddress": {
             "Type": "String",
-            "Description": "Address from which notifications come"
+            "Description": "Address from which notifications come",
+            "Default": "tableau@outra.co.uk"
         },
         "SmtpAlertToAddress": {
             "Type": "String",
-            "Description": "Address to which server alerts are sent"
+            "Description": "Address to which server alerts are sent",
+            "Default": "awsaccount-dev@outra.co.uk"
         },
         "SmtpUserName": {
             "Type": "String",
@@ -46,43 +49,55 @@
             "Type": "AWS::EC2::KeyPair::KeyName"
         },
         "RegCity": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "London"
         },
         "RegCompany": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "Outra Ltd"
         },
         "RegCountry": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "UK"
         },
         "RegDepartment": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "Technology"
         },
         "RegEmail": {
             "MinLength": "1",
-            "Type": "String"
+            "Type": "String",
+            "Default": "it@outra.co.uk"
         },
         "RegFirstName": {
             "MinLength": "1",
-            "Type": "String"
+            "Type": "String",
+            "Default": "Cyril"
         },
         "RegIndustry": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "Big Data"
         },
         "RegLastName": {
             "MinLength": "1",
-            "Type": "String"
+            "Type": "String",
+            "Default": "Law"
         },
         "RegPhone": {
-            "Type": "String"
+            "Type": "String",
+            "Default": ""
         },
         "RegState": {
-            "Type": "String"
+            "Type": "String",
+            "Default": ""
         },
         "RegTitle": {
-            "Type": "String"
+            "Type": "String",
+            "Default": ""
         },
         "RegZip": {
-            "Type": "String"
+            "Type": "String",
+            "Default": "SW1 00XF"
         },
         "TableauServerLicenseKey": {
             "Description": "License Key (leave blank for trial)",
@@ -111,7 +126,7 @@
         "DataVolumeSize": {
             "Description": "The size of this server's Data volume in GB",
             "Type": "Number",
-            "Default": "100"
+            "Default": "1000"
         }
     },
     "Metadata": {


### PR DESCRIPTION
This takes the base single server AWS quickstart template and does the following:

* Removes responsibility for creating security groups
* Parameterises a number of network options
* Adds SMTP configuration
* Re-uses some of the cluster template's advanced configuration techniques
* Stores the parameters we used for the outra-data and outra-dev accounts
